### PR TITLE
fix: Pass GITHUB_TOKEN to create-or-update-comment

### DIFF
--- a/.github/workflows/agent-orchestrator.yml
+++ b/.github/workflows/agent-orchestrator.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: ${{ steps.gemini.outputs.stdout }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Call Claude Agent
         if: contains(github.event.comment.body, 'claude')


### PR DESCRIPTION
This PR ensures the GITHUB_TOKEN is passed to the create-or-update-comment action.