### PR TITLE
fix: Parse Gemini output before commenting

### DIFF
--- a/.github/workflows/agent-orchestrator.yml
+++ b/.github/workflows/agent-orchestrator.yml
@@ -30,7 +30,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.issue.number }}
-          body: ${{ steps.gemini.outputs.stdout }}
+          body: ${{ steps.gemini.outputs.stdout | sed 's/^.*is //' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Call Claude Agent


### PR DESCRIPTION
This PR parses the Gemini output to extract only the answer before commenting.