### PR TITLE
fix: Add id-token permission to fix Claude OIDC authentication

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -13,6 +13,7 @@ permissions:
   discussions: read
   repository-projects: read
   statuses: read
+  id-token: write
 
 jobs:
   handle-claude-request:

--- a/.github/workflows/claude-simple.yml
+++ b/.github/workflows/claude-simple.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

Claude agent workflows were failing with OIDC authentication error:
```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

## Root Cause

The Claude Code action requires `id-token: write` permission to authenticate with Anthropic's services using OIDC tokens. This permission was missing from our workflows.

## Solution

Added `id-token: write` permission to:
- `claude-simple.yml` 
- `claude-issue-handler.yml`

## Testing

After this fix, the Claude agent should be able to authenticate properly and respond to @claude and @claude-test mentions in issues.

## Related

This fixes the failures we were seeing in GitHub Actions where Claude agent couldn't get OIDC tokens for authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)